### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: Formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Check Formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
     - name: Login to crates.io
       run: cargo login $CRATES_IO_TOKEN
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,9 @@ jobs:
         rust: [stable]
 
     steps:
-    - uses: hecrj/setup-rust-action@v2
+    - uses: hecrj/setup-rust-action@110f36749599534ca96628b82f52ae67e5d95a3c # v2
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: actions/checkout@master
+    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/checkout@v1` -> `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0`
  - Version: v1.2.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/50fbc622fc4ef5163becd7fab6573eac35f8462e

- `hecrj/setup-rust-action@v2` -> `hecrj/setup-rust-action@110f36749599534ca96628b82f52ae67e5d95a3c # v2`
  - Version: v2 | Latest: v2.0.1 | Release age: 759d
  - Commit: https://github.com/hecrj/setup-rust-action/commit/110f36749599534ca96628b82f52ae67e5d95a3c

- `actions/checkout@master` -> `actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master`
  - Version: master | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/61b9e3751b92087fd0b06925ba6dd6314e06f089


### Files modified

- `.github/workflows/lint.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/rust.yml`